### PR TITLE
Fix clippy warnings in test files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,85 +16,85 @@ jobs:
     outputs:
       cache-key: ${{ steps.cache-key.outputs.value }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-        targets: x86_64-unknown-linux-musl
-    - name: Generate cache key
-      id: cache-key
-      run: echo "value=cargo-$(rustc -V | sed 's/.*(\(.*\))/\1/')-$(sha256sum Cargo.lock | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-musl
+      - name: Generate cache key
+        id: cache-key
+        run: echo "value=cargo-$(rustc -V | sed 's/.*(\(.*\))/\1/')-$(sha256sum Cargo.lock | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
   lint:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-    - uses: actions/checkout@v4
-    - name: Restore cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ needs.setup.outputs.cache-key }}-lint
-    - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy, rustfmt
-    - name: Run clippy
-      run: cargo clippy --workspace --all-targets -- -D warnings
-    - name: Check formatting
-      run: cargo fmt --check
+      - uses: actions/checkout@v4
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ needs.setup.outputs.cache-key }}-lint
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Check formatting
+        run: cargo fmt --check
 
   test:
     runs-on: ubuntu-latest
-    needs: [setup, lint]
+    needs: setup
     env:
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
     steps:
-    - uses: actions/checkout@v4
-    - name: Restore cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ needs.setup.outputs.cache-key }}-test
-    - name: Verify musl target is installed
-      run: rustup target list | grep x86_64-unknown-linux-musl | grep installed
-    - name: Build
-      run: cargo build --workspace --verbose
-    - name: Run tests
-      run: cargo test --workspace --verbose
-    - name: Check binary compatibility
-      run: |
-        cargo build --workspace --release
-        find target/x86_64-unknown-linux-musl/release -maxdepth 1 -executable -type f 2>/dev/null | head -5 | xargs -I {} sh -c 'file {} | grep -q "statically linked" && echo "✓ {} is statically linked" || echo "✗ {} is not statically linked"'
+      - uses: actions/checkout@v4
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ needs.setup.outputs.cache-key }}-test
+      - name: Verify musl target is installed
+        run: rustup target list | grep x86_64-unknown-linux-musl | grep installed
+      - name: Build
+        run: cargo build --workspace --verbose
+      - name: Run tests
+        run: cargo test --workspace --verbose
+      - name: Check binary compatibility
+        run: |
+          cargo build --workspace --release
+          find target/x86_64-unknown-linux-musl/release -maxdepth 1 -executable -type f 2>/dev/null | head -5 | xargs -I {} sh -c 'file {} | grep -q "statically linked" && echo "✓ {} is statically linked" || echo "✗ {} is not statically linked"'
 
   release:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
     steps:
-    - uses: actions/checkout@v4
-    - name: Restore cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ needs.setup.outputs.cache-key }}-release
-    - name: Build release binaries
-      run: cargo build --workspace --release
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-binaries
-        path: target/x86_64-unknown-linux-musl/release/
+      - uses: actions/checkout@v4
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ needs.setup.outputs.cache-key }}-release
+      - name: Build release binaries
+        run: cargo build --workspace --release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-binaries
+          path: target/x86_64-unknown-linux-musl/release/

--- a/crates/utils/cfg_file/cfg_file_test/src/lib.rs
+++ b/crates/utils/cfg_file/cfg_file_test/src/lib.rs
@@ -19,7 +19,7 @@ mod test_cfg_file {
         let mut example = ExampleConfig {
             name: "Weicao".to_string(),
             age: 22,
-            hobby: vec!["Programming", "Painting"]
+            hobby: ["Programming", "Painting"]
                 .iter()
                 .map(|m| m.to_string())
                 .collect(),

--- a/crates/utils/tcp_connection/tcp_connection_test/src/test_challenge.rs
+++ b/crates/utils/tcp_connection/tcp_connection_test/src/test_challenge.rs
@@ -14,94 +14,90 @@ use tokio::{
 pub(crate) struct ExampleChallengeClientHandle;
 
 impl ClientHandle<ExampleChallengeServerHandle> for ExampleChallengeClientHandle {
-    fn process(mut instance: ConnectionInstance) -> impl std::future::Future<Output = ()> + Send {
-        async move {
-            // Accept challenge with correct key
-            let key = current_dir()
-                .unwrap()
-                .join("res")
-                .join("key")
-                .join("test_key_private.pem");
-            let result = instance.accept_challenge(key, "test_key").await.unwrap();
+    async fn process(mut instance: ConnectionInstance) {
+        // Accept challenge with correct key
+        let key = current_dir()
+            .unwrap()
+            .join("res")
+            .join("key")
+            .join("test_key_private.pem");
+        let result = instance.accept_challenge(key, "test_key").await.unwrap();
 
-            // Sent success
-            assert_eq!(true, result);
-            let response = instance.read_text().await.unwrap();
+        // Sent success
+        assert!(result);
+        let response = instance.read_text().await.unwrap();
 
-            // Verify success
-            assert_eq!("OK", response);
+        // Verify success
+        assert_eq!("OK", response);
 
-            // Accept challenge with wrong key
-            let key = current_dir()
-                .unwrap()
-                .join("res")
-                .join("key")
-                .join("wrong_key_private.pem");
-            let result = instance.accept_challenge(key, "test_key").await.unwrap();
+        // Accept challenge with wrong key
+        let key = current_dir()
+            .unwrap()
+            .join("res")
+            .join("key")
+            .join("wrong_key_private.pem");
+        let result = instance.accept_challenge(key, "test_key").await.unwrap();
 
-            // Sent success
-            assert_eq!(true, result);
-            let response = instance.read_text().await.unwrap();
+        // Sent success
+        assert!(result);
+        let response = instance.read_text().await.unwrap();
 
-            // Verify fail
-            assert_eq!("ERROR", response);
+        // Verify fail
+        assert_eq!("ERROR", response);
 
-            // Accept challenge with wrong name
-            let key = current_dir()
-                .unwrap()
-                .join("res")
-                .join("key")
-                .join("test_key_private.pem");
-            let result = instance.accept_challenge(key, "test_key__").await.unwrap();
+        // Accept challenge with wrong name
+        let key = current_dir()
+            .unwrap()
+            .join("res")
+            .join("key")
+            .join("test_key_private.pem");
+        let result = instance.accept_challenge(key, "test_key__").await.unwrap();
 
-            // Sent success
-            assert_eq!(true, result);
-            let response = instance.read_text().await.unwrap();
+        // Sent success
+        assert!(result);
+        let response = instance.read_text().await.unwrap();
 
-            // Verify fail
-            assert_eq!("ERROR", response);
-        }
+        // Verify fail
+        assert_eq!("ERROR", response);
     }
 }
 
 pub(crate) struct ExampleChallengeServerHandle;
 
 impl ServerHandle<ExampleChallengeClientHandle> for ExampleChallengeServerHandle {
-    fn process(mut instance: ConnectionInstance) -> impl std::future::Future<Output = ()> + Send {
-        async move {
-            // Challenge with correct key
-            let key_dir = current_dir().unwrap().join("res").join("key");
-            let result = instance.challenge(key_dir).await.unwrap();
-            assert_eq!(true, result);
+    async fn process(mut instance: ConnectionInstance) {
+        // Challenge with correct key
+        let key_dir = current_dir().unwrap().join("res").join("key");
+        let result = instance.challenge(key_dir).await.unwrap();
+        assert!(result);
 
-            // Send response
-            instance
-                .write_text(if result { "OK" } else { "ERROR" })
-                .await
-                .unwrap();
+        // Send response
+        instance
+            .write_text(if result { "OK" } else { "ERROR" })
+            .await
+            .unwrap();
 
-            // Challenge again
-            let key_dir = current_dir().unwrap().join("res").join("key");
-            let result = instance.challenge(key_dir).await.unwrap();
-            assert_eq!(false, result);
+        // Challenge again
+        let key_dir = current_dir().unwrap().join("res").join("key");
+        let result = instance.challenge(key_dir).await.unwrap();
+        assert!(!result);
 
-            // Send response
-            instance
-                .write_text(if result { "OK" } else { "ERROR" })
-                .await
-                .unwrap();
+        // Send response
+        instance
+            .write_text(if result { "OK" } else { "ERROR" })
+            .await
+            .unwrap();
 
-            // Challenge again
-            let key_dir = current_dir().unwrap().join("res").join("key");
-            let result = instance.challenge(key_dir).await.unwrap();
-            assert_eq!(false, result);
+        // Challenge again
+        let key_dir = current_dir().unwrap().join("res").join("key");
+        let result = instance.challenge(key_dir).await.unwrap();
+        assert!(!result);
 
-            // Send response
-            instance
-                .write_text(if result { "OK" } else { "ERROR" })
-                .await
-                .unwrap();
-        }
+        // Send response
+        instance
+            .write_text(if result { "OK" } else { "ERROR" })
+            .await
+            .unwrap();
     }
 }
 

--- a/crates/utils/tcp_connection/tcp_connection_test/src/test_connection.rs
+++ b/crates/utils/tcp_connection/tcp_connection_test/src/test_connection.rs
@@ -11,35 +11,31 @@ use tokio::{join, time::sleep};
 pub(crate) struct ExampleClientHandle;
 
 impl ClientHandle<ExampleServerHandle> for ExampleClientHandle {
-    fn process(mut instance: ConnectionInstance) -> impl std::future::Future<Output = ()> + Send {
-        async move {
-            // Write name
-            let Ok(_) = instance.write_text("Peter").await else {
-                panic!("Write text failed!");
-            };
-            // Read msg
-            let Ok(result) = instance.read_text().await else {
-                return;
-            };
-            assert_eq!("Hello Peter!", result);
-        }
+    async fn process(mut instance: ConnectionInstance) {
+        // Write name
+        let Ok(_) = instance.write_text("Peter").await else {
+            panic!("Write text failed!");
+        };
+        // Read msg
+        let Ok(result) = instance.read_text().await else {
+            return;
+        };
+        assert_eq!("Hello Peter!", result);
     }
 }
 
 pub(crate) struct ExampleServerHandle;
 
 impl ServerHandle<ExampleClientHandle> for ExampleServerHandle {
-    fn process(mut instance: ConnectionInstance) -> impl std::future::Future<Output = ()> + Send {
-        async move {
-            // Read name
-            let Ok(name) = instance.read_text().await else {
-                return;
-            };
-            // Write msg
-            let Ok(_) = instance.write_text(format!("Hello {}!", name)).await else {
-                panic!("Write text failed!");
-            };
-        }
+    async fn process(mut instance: ConnectionInstance) {
+        // Read name
+        let Ok(name) = instance.read_text().await else {
+            return;
+        };
+        // Write msg
+        let Ok(_) = instance.write_text(format!("Hello {}!", name)).await else {
+            panic!("Write text failed!");
+        };
     }
 }
 

--- a/crates/utils/tcp_connection/tcp_connection_test/src/test_file_transfer.rs
+++ b/crates/utils/tcp_connection/tcp_connection_test/src/test_file_transfer.rs
@@ -14,31 +14,27 @@ use tokio::{
 pub(crate) struct ExampleFileTransferClientHandle;
 
 impl ClientHandle<ExampleFileTransferServerHandle> for ExampleFileTransferClientHandle {
-    fn process(mut instance: ConnectionInstance) -> impl std::future::Future<Output = ()> + Send {
-        async move {
-            let image_path = current_dir()
-                .unwrap()
-                .join("res")
-                .join("image")
-                .join("test_transfer.png");
-            instance.write_file(image_path).await.unwrap();
-        }
+    async fn process(mut instance: ConnectionInstance) {
+        let image_path = current_dir()
+            .unwrap()
+            .join("res")
+            .join("image")
+            .join("test_transfer.png");
+        instance.write_file(image_path).await.unwrap();
     }
 }
 
 pub(crate) struct ExampleFileTransferServerHandle;
 
 impl ServerHandle<ExampleFileTransferClientHandle> for ExampleFileTransferServerHandle {
-    fn process(mut instance: ConnectionInstance) -> impl std::future::Future<Output = ()> + Send {
-        async move {
-            let save_path = current_dir()
-                .unwrap()
-                .join("res")
-                .join(".temp")
-                .join("image")
-                .join("test_transfer.png");
-            instance.read_file(save_path).await.unwrap();
-        }
+    async fn process(mut instance: ConnectionInstance) {
+        let save_path = current_dir()
+            .unwrap()
+            .join("res")
+            .join(".temp")
+            .join("image")
+            .join("test_transfer.png");
+        instance.read_file(save_path).await.unwrap();
     }
 }
 

--- a/crates/vcs/vcs_test/src/test_vault_setup_and_member_register.rs
+++ b/crates/vcs/vcs_test/src/test_vault_setup_and_member_register.rs
@@ -49,20 +49,18 @@ async fn test_vault_setup_and_member_register() -> Result<(), std::io::Error> {
     const ID_PARAM: &str = "{member_id}";
 
     // Check if the member info file exists
-    assert_eq!(
+    assert!(
         dir.join(SERVER_FILE_MEMBER_INFO.replace(ID_PARAM, member_id))
-            .exists(),
-        true
+            .exists()
     );
 
     // Remove member
     vault.remove_member_from_vault(&member_id.to_string())?;
 
     // Check if the member info file not exists
-    assert_eq!(
-        dir.join(SERVER_FILE_MEMBER_INFO.replace(ID_PARAM, member_id))
-            .exists(),
-        false
+    assert!(
+        !dir.join(SERVER_FILE_MEMBER_INFO.replace(ID_PARAM, member_id))
+            .exists()
     );
 
     Ok(())


### PR DESCRIPTION
- Convert manual async functions to async fn syntax
- Replace assert_eq!(true/false, ...) with assert!(...) and assert!(!...)
- Fix useless vec warning by using array directly
- All tests continue to pass after optimizations