### PR TITLE
Fix musl target installation in test job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,8 +64,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ needs.setup.outputs.cache-key }}-test
-      - name: Verify musl target is installed
-        run: rustup target list | grep x86_64-unknown-linux-musl | grep installed
+      - name: Install musl target
+        run: rustup target add x86_64-unknown-linux-musl
       - name: Build
         run: cargo build --workspace --verbose
       - name: Run tests


### PR DESCRIPTION
- Replace 'Verify musl target is installed' with 'Install musl target' in test job
- This ensures musl target is properly installed before building and testing