### PR TITLE
Remove cargo fmt check from workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,8 +46,6 @@ jobs:
           components: clippy, rustfmt
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-      - name: Check formatting
-        run: cargo fmt --check
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           toolchain: stable
           targets: x86_64-unknown-linux-musl
+      - name: Install musl development tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Generate cache key
         id: cache-key
         run: echo "value=cargo-$(rustc -V | sed 's/.*(\(.*\))/\1/')-$(sha256sum Cargo.lock | cut -d' ' -f1)" >> $GITHUB_OUTPUT
@@ -62,8 +64,10 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ needs.setup.outputs.cache-key }}-test
-      - name: Install musl target
-        run: rustup target add x86_64-unknown-linux-musl
+      - name: Install musl target and tools
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Build
         run: cargo build --workspace --verbose
       - name: Run tests


### PR DESCRIPTION
- Remove the 'Check formatting' step that runs 'cargo fmt --check'
- Keep clippy checks for code quality but remove formatting enforcement